### PR TITLE
Create Dapps Score

### DIFF
--- a/Dapps Score
+++ b/Dapps Score
@@ -1,0 +1,13 @@
+## Values To Imbue In Our Smart Agents & For Dev Contributions To Be Ranked By
+- Open Source: The software code underpinning the Smart Agents must be freely reviewable, editable & copyable by all.
+- Peer to Peer: A system which allows for direct connection by all and is free of centralized intermediaries in all their functions.
+- Public Blockchain: A distributed public immutable ledger / system of record for interactions of the Smart Agent. This can be used as proof that a Smart Agent is following its own rules and offers a high level of transparency in the system.
+- Tokenized Ownership: Setting forth the means of rewarding participants & stakeholders contributing to Smart Agents.
+- Permissionless: No one should be required to ask an authority to access their Smart Agent.
+- Freedom of Access: No one should have their use of the Smart Agent blocked or otherwise censored.
+- Privacy Preserving: No one should have to expose their private information to use their Smart Agent.
+- Freedom of Exit: Acts taken by the Smart Agent should have a means of a defined exit from participation.
+- Self Sovereign Identity: All users have the power to generate their own identities and their consent is required to use those credentials.
+- Freedom of Association: All those using Smart Agents maintain their independence and freedom of association. 
+
+Ranking each blockchain, Dapp, DAO, & Smart contract will generate a Dapps Score. These criteria will go into the calculation of how to weight the Smart Contracts in the KeyWeb3 LLM dataset and thus down rank high risk or centralized options in favor of open source decentralized options. 


### PR DESCRIPTION
Ranking each blockchain, Dapp, DAO, & Smart contract will generate a Dapps Score. These criteria will go into the calculation of how to weight the Smart Contracts in the KeyWeb3 LLM dataset and thus down rank high risk or centralized options in favor of open source decentralized options.